### PR TITLE
chore(workflow): Add automated issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/nueva-funcionalidad.md
+++ b/.github/ISSUE_TEMPLATE/nueva-funcionalidad.md
@@ -1,0 +1,27 @@
+---
+name: "🚀 Nueva Funcionalidad"
+description: "Sugiere una nueva idea, mejora o característica para el proyecto."
+title: "feat: [Título conciso de la funcionalidad]"
+labels: ["feature", "needs-triage"]
+assignees: ''
+---
+
+### Descripción
+**User Story:** Como [tipo de usuario], quiero [acción] para poder [beneficio].
+
+### Nombre de Rama Sugerido (Opcional)
+`feature/`
+
+### Tareas Propuestas (Checklist)
+- [ ] Tarea técnica 1
+- [ ] Tarea técnica 2
+- [ ] Tarea técnica 3
+
+### Definición de 'Hecho' (Definition of Done)
+- [ ] El código está cubierto por pruebas automatizadas.
+- [ ] La documentación relevante ha sido actualizada.
+- [ ] El Pull Request asociado ha sido revisado y aprobado.
+- [ ] La funcionalidad cumple con los requisitos descritos.
+
+### Dependencias
+<!-- (Opcional) Si esta issue depende de otra, vincúlala aquí. -->

--- a/.github/ISSUE_TEMPLATE/reporte-bug.md
+++ b/.github/ISSUE_TEMPLATE/reporte-bug.md
@@ -1,0 +1,24 @@
+---
+name: "🐞 Reporte de Bug"
+description: "Reporta un error o comportamiento inesperado."
+title: "fix: [Título conciso del bug]"
+labels: ["bug", "needs-triage"]
+assignees: ''
+---
+
+### Describe el Bug
+Una descripción clara y concisa de cuál es el problema.
+
+### Nombre de Rama Sugerido (Opcional)
+`bugfix/`
+
+### Pasos para Reproducir
+1. Ir a '...'
+2. Hacer clic en '....'
+3. Ver el error
+
+### Comportamiento Esperado
+Una descripción clara de lo que esperabas que sucediera.
+
+### Contexto Adicional (Opcional)
+<!-- Añade capturas de pantalla, logs, o cualquier otro contexto sobre el problema aquí. -->


### PR DESCRIPTION
#### Descripción

Este PR introduce las plantillas de issues automatizadas de GitHub para estandarizar el proceso de creación de nuevas tareas. El objetivo es asegurar que todos los reportes de bugs y propuestas de funcionalidades sigan un formato consistente y proporcionen la información necesaria desde el principio.

#### Cambios Realizados

-   Se ha creado la estructura de carpetas `.github/ISSUE_TEMPLATE/`.
-   Se han añadido dos plantillas de issue:
    -   `nueva-funcionalidad.md` (para features).
    -   `reporte-bug.md` (para bugs).

#### ¿Cómo verificar?

1.  Una vez fusionado este PR.
2.  Ve a la pestaña de **"Issues"** del repositorio.
3.  Haz clic en el botón **"New Issue"**.
4.  Deberías ver una nueva pantalla para seleccionar entre la plantilla de "**🚀 Nueva Funcionalidad**" y "**🐞 Reporte de Bug**".