### PR TITLE
fix(layout): prevent auth form overlapping header on low-height viewports

### DIFF
--- a/src/components/layouts/AuthLayout.tsx
+++ b/src/components/layouts/AuthLayout.tsx
@@ -3,7 +3,7 @@ import { BookOpen, ArrowLeft } from 'lucide-react';
 
 const AuthLayout = () => {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 via-white to-green-50">
+    <div className="relative min-h-screen w-full flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 via-white to-green-50">
       <div className="absolute top-6 left-6">
         <Link
           to="/"


### PR DESCRIPTION
Close #41 

### Descripción
Este PR soluciona un bug visual crítico en los formularios de autenticación (Login y Registro) que ocurre en dispositivos con poca altura. El problema principal era que, al reducir la altura del viewport, el formulario se superponía con el botón de navegación superior ('UpSkill'), dejándolo inaccesible y afectando la usabilidad.

Este cambio asegura que el layout sea robusto y funcional en todas las resoluciones, especialmente en móviles con pantallas de baja altura.

### Cambios Realizados
*   **En `src/components/layouts/AuthLayout.tsx`:**
    *   Se ha añadido `position: relative` al contenedor principal para establecer un contexto de posicionamiento para el botón de navegación

### ¿Cómo verificar?
1.  Una vez que hayas hecho checkout a la rama de este PR (`bugfix/auth-layout-overlap`).
2.  Navega a la página de `/login` o `/register`.
3.  Abre las herramientas de desarrollador del navegador y activa el modo de diseño responsivo.
4.  Establece una resolución con poca altura, por ejemplo: **360px de ancho x 550px de alto**.
5.  **Comportamiento esperado:** El botón "UpSkill" debe ser completamente visible y funcional en la parte superior. El formulario debe aparecer debajo de él, sin solapamientos. La página debe permitir hacer scroll vertical si el contenido del formulario excede la altura de la pantalla.