### PR TITLE
refactor: Migrar el manejo de estado del servidor a TanStack Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "pnpm run lint && pnpm run type-check && pnpm run audit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.6",
     "axios": "^1.10.0",
     "lucide-react": "^0.534.0",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.85.6",
+    "@tanstack/react-query-devtools": "^5.85.6",
     "axios": "^1.10.0",
     "lucide-react": "^0.534.0",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.85.6
+        version: 5.85.6(react@19.1.0)
       axios:
         specifier: ^1.10.0
         version: 1.10.0
@@ -538,6 +541,14 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@tanstack/query-core@5.85.6':
+    resolution: {integrity: sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==}
+
+  '@tanstack/react-query@5.85.6':
+    resolution: {integrity: sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
@@ -2087,6 +2098,13 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@tanstack/query-core@5.85.6': {}
+
+  '@tanstack/react-query@5.85.6(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.85.6
+      react: 19.1.0
 
   '@tweenjs/tween.js@23.1.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.85.6
         version: 5.85.6(react@19.1.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.85.6
+        version: 5.85.6(@tanstack/react-query@5.85.6(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.10.0
         version: 1.10.0
@@ -544,6 +547,15 @@ packages:
 
   '@tanstack/query-core@5.85.6':
     resolution: {integrity: sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==}
+
+  '@tanstack/query-devtools@5.84.0':
+    resolution: {integrity: sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==}
+
+  '@tanstack/react-query-devtools@5.85.6':
+    resolution: {integrity: sha512-A6rE39FypFV7eonefk4fxC/vuV/7YJMAcQT94CFAvCpiw65QZX8MOuUpdLBeG1cXajy4Pj8T8sEWHigccntJqg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.85.6
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.85.6':
     resolution: {integrity: sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==}
@@ -2100,6 +2112,14 @@ snapshots:
   '@standard-schema/utils@0.3.0': {}
 
   '@tanstack/query-core@5.85.6': {}
+
+  '@tanstack/query-devtools@5.84.0': {}
+
+  '@tanstack/react-query-devtools@5.85.6(@tanstack/react-query@5.85.6(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.84.0
+      '@tanstack/react-query': 5.85.6(react@19.1.0)
+      react: 19.1.0
 
   '@tanstack/react-query@5.85.6(react@19.1.0)':
     dependencies:

--- a/src/hooks/useAppeals.ts
+++ b/src/hooks/useAppeals.ts
@@ -1,0 +1,22 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { appealService } from '../api/services/appeal.service';
+
+export const useAppeals = () => {
+  return useQuery({
+    queryKey: ['appeals'],
+    queryFn: appealService.findAllAppeals,
+  });
+};
+
+export const useUpdateAppealState = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ appealId, payload }: { appealId: string; payload: { state: 'accepted' | 'rejected' } }) => 
+      appealService.updateAppealState(appealId, payload),
+    
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['appeals'] });
+    },
+  });
+};

--- a/src/hooks/useAuthMutations.ts
+++ b/src/hooks/useAuthMutations.ts
@@ -1,0 +1,46 @@
+import { useMutation } from '@tanstack/react-query'
+import { authService } from '../api/services/auth.service'
+import { useAuth } from './useAuth'
+import { useNavigate } from 'react-router-dom'
+
+export const useLogin = () => {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+
+  return useMutation({
+    mutationFn: authService.login,
+    onSuccess: (token) => {
+      login(token) 
+      navigate('/')
+    },
+  })
+}
+
+export const useRegister = () => {
+  const navigate = useNavigate()
+  return useMutation({
+    mutationFn: authService.register,
+    onSuccess: () => {
+      alert("¡Registro exitoso! Por favor, inicia sesión.")
+      navigate('/login')
+    },
+  })
+}
+
+export const useForgotPassword = () => {
+  return useMutation({
+    mutationFn: (email: string) => authService.forgotPassword(email),
+  })
+}
+
+export const useResetPassword = () => {
+  const navigate = useNavigate()
+  return useMutation({
+    mutationFn: ({ token, password }: { token: string; password: string }) =>
+      authService.resetPassword(token, password),
+    onSuccess: () => {
+      alert("¡Contraseña actualizada con éxito!");
+      navigate('/login');
+    },
+  })
+}

--- a/src/hooks/useCourseTypes.ts
+++ b/src/hooks/useCourseTypes.ts
@@ -1,0 +1,41 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { courseTypeService } from '../api/services/courseType.service';
+import type { CourseType } from '../types/entities';
+
+export const useCourseTypes = () => {
+  return useQuery({
+    queryKey: ['courseTypes'],
+    queryFn: courseTypeService.findAll,
+  });
+};
+
+export const useCreateCourseType = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Omit<CourseType, 'id' | 'courses'>) => courseTypeService.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['courseTypes'] });
+    },
+  });
+};
+
+export const useUpdateCourseType = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string, data: Omit<CourseType, 'id' | 'courses'> }) => 
+      courseTypeService.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['courseTypes'] });
+    },
+  });
+};
+
+export const useDeleteCourseType = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => courseTypeService.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['courseTypes'] });
+    },
+  });
+};

--- a/src/hooks/useCreateAppeal.ts
+++ b/src/hooks/useCreateAppeal.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { appealService } from '../api/services/appeal.service';
+import { useNavigate } from 'react-router-dom';
+
+export const useCreateAppeal = () => {
+  const navigate = useNavigate();
+  return useMutation({
+    mutationFn: (formData: FormData) => appealService.createAppeal(formData),
+    onSuccess: () => {
+      alert("¡Solicitud enviada con éxito! Te contactaremos pronto.");
+      navigate('/');
+    },
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.tsx';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App.tsx';
 import './index.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60,
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -13,6 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/src/pages/Auth/ForgotPasswordPage.tsx
@@ -1,38 +1,21 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import type React from 'react';
-import axios from 'axios';
-import { Mail, CheckCircle } from 'lucide-react';
-import { authService } from '../../api/services/auth.service';
-import Button from '../../components/ui/Button';
-import Input from '../../components/ui/Input';
-import AuthCard from '../../components/layouts/AuthCard';
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type React from 'react'
+import { Mail, CheckCircle } from 'lucide-react'
+import { useForgotPassword } from '../../hooks/useAuthMutations.ts'
+import Button from '../../components/ui/Button'
+import Input from '../../components/ui/Input'
+import AuthCard from '../../components/layouts/AuthCard'
+import { isAxiosError } from 'axios'
 
 const ForgotPasswordPage = () => {
-  const [email, setEmail] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSuccess, setIsSuccess] = useState(false);
+  const [email, setEmail] = useState('')
+  const { mutate: sendLink, isPending, isSuccess, error } = useForgotPassword()
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setError(null);
-    setIsSuccess(false);
-
-    try {
-      await authService.forgotPassword(email);
-      setIsSuccess(true);
-    } catch (err) {
-      const message =
-        axios.isAxiosError(err) && err.response?.data?.message
-          ? err.response.data.message
-          : 'No se pudo procesar la solicitud. Inténtalo de nuevo.';
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    e.preventDefault()
+    sendLink(email)
+  }
 
   return (
     <AuthCard
@@ -64,12 +47,16 @@ const ForgotPasswordPage = () => {
             autoComplete="email"
             />
 
-            {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+            {error && (
+              <p className="text-sm text-red-500 text-center">
+                {isAxiosError(error) ? error.response?.data?.message : 'No se pudo procesar la solicitud.'}
+              </p>
+            )}
 
             <div className="pt-2">
             <Button
                 type="submit"
-                isLoading={isLoading}
+                isLoading={isPending}
                 className="w-full text-base py-3"
             >
                 Enviar Enlace
@@ -87,7 +74,7 @@ const ForgotPasswordPage = () => {
         </form>
       )}
     </AuthCard>
-  );
-};
+  )
+}
 
-export default ForgotPasswordPage;
+export default ForgotPasswordPage

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -11,7 +11,7 @@ import AdminDashboard from '../pages/Admin/AdminDashboard';
 import ProfessorDashboard from '../pages/Professor/ProfessorDashboard';
 import UnauthorizedPage from '../pages/UnauthorizedPage';
 import ProtectedRoute from './ProtectedRoute';
-import { ProfessorApplication } from '../pages/Professor/ProfessorApplication';
+import ProfessorAppeal from '../pages/Professor/ProfessorAppeal.tsx';
 import ProfessorAppealsPage from '../pages/Admin/ProfessorAppealsPage.tsx';
 import UsersPage from '../pages/Admin/UsersPage.tsx';
 import AnalyticsPage from '../pages/Admin/AnalyticsPage.tsx';
@@ -47,7 +47,7 @@ const AppRouter = () => {
             <Route path="students" element={<ProfessorStudentsPage />} />
         </Route>
 
-        <Route path="/professor/apply" element={<ProtectedRoute allowedRoles={['admin', 'student']}><ProfessorApplication /></ProtectedRoute>} />
+        <Route path="/professor/apply" element={<ProtectedRoute allowedRoles={['admin', 'student']}><ProfessorAppeal /></ProtectedRoute>} />
 
         <Route path="/admin" element={<ProtectedRoute allowedRoles={['admin']}><Navigate to="/admin/dashboard" replace /></ProtectedRoute>} />
         <Route path="/admin/dashboard" element={<ProtectedRoute allowedRoles={['admin']}><AdminDashboard /></ProtectedRoute>} />


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
Closes #71

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
-->
Este PR refactoriza por completo el manejo del estado del servidor en la aplicación, migrando toda la lógica de obtención y mutación de datos desde `useState`/`useEffect` manuales hacia **TanStack Query (React Query)**. Esto resulta en un código más simple y declarativo, a la vez que mejora la experiencia del usuario con caché inteligente.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
-->
- **Configuración Inicial y Herramientas:**
    -   Se han instalado las dependencias `@tanstack/react-query` y `@tanstack/react-query-devtools`.
    -   Se ha configurado el `QueryClientProvider` en `main.tsx`, estableciendo el sistema de caché global.
    -   Se han integrado las **React Query Devtools** para facilitar la depuración y visualización del estado de las queries en desarrollo.
    -   Se ha establecido un `staleTime` global de 1 minuto para todas las queries, optimizando el comportamiento del cacheo y evitando refetches innecesarios en datos que no cambian con frecuencia.

- **Creación de Hooks Personalizados:**
    -   **`useAppeals.ts`:** Se han creado los hooks `useAppeals` (con `useQuery`) y `useUpdateAppealState` (con `useMutation`) para gestionar las solicitudes de profesor.
    -   **`useCourseTypes.ts`:** Se han implementado los hooks para el ciclo CRUD completo (`useCourseTypes`, `useCreateCourseType`, `useUpdateCourseType`, `useDeleteCourseType`).
    -   **`useAuthMutations.ts`:** Se han creado hooks de mutación (`useLogin`, `useRegister`, `useForgotPassword`, `useResetPassword`) para manejar todas las operaciones del flujo de autenticación.

- **Refactorización de Componentes de Página:**
    -   **`ProfessorRequestsPage.tsx`:** Se ha refactorizado para usar `useAppeals` y `useUpdateAppealState`, eliminando la lógica manual de `useEffect` y `useState` para la gestión de datos.
    -   **`CourseTypesPage.tsx`:** Se ha refactorizado para usar los nuevos hooks CRUD, simplificando enormemente la lógica del formulario y la gestión de la lista.
    -   **Formularios de Autenticación (`LoginPage`, `RegisterPage`, etc.):** Todos los formularios que realizan mutaciones ahora utilizan sus respectivos hooks, delegando el manejo de los estados de carga y error.

- **Manejo de Errores Mejorado:**
    -   Se ha implementado el uso del type guard `isAxiosError` en los componentes que manejan errores de mutación para acceder de forma segura a los mensajes de error de la API.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
-->
1.  Iniciar el servidor del frontend (`pnpm dev`) y el del backend.
2.  **Verificar las Devtools y el `staleTime`:**
    -   Abrir la aplicación y hacer clic en el ícono de TanStack Query en la esquina inferior izquierda para abrir las devtools.
    -   Navegar a `/admin/appeals`. Observar que la query `['appeals']` pasa a estado **verde (`fresh`)**.
    -   Navegar a otra página y volver a la de solicitudes (dentro de un minuto). **Verificar que no se realiza una nueva petición en la pestaña "Network"** y que la query sigue en verde.
3.  **Probar Flujo de Autenticación:**
    -   Verificar que el registro, inicio de sesión, y recuperación de contraseña funcionan correctamente, utilizando los nuevos hooks de mutación.
4.  **Probar Panel de Administrador (Vistas Refactorizadas):**
    -   Navegar a `/admin/appeals`. Probar las acciones de "Aprobar" y "Rechazar" y confirmar que la lista se **actualiza automáticamente** (refetch) después de la acción.
    -   Navegar a `/admin/courseTypes`. Probar el ciclo completo de Crear, Editar y Eliminar y verificar que la lista se actualiza automáticamente.