### PR TITLE
refactor: Migrar gestión de formularios a React Hook Form y Valibot

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,18 @@
     "test": "pnpm run lint && pnpm run type-check && pnpm run audit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "@tanstack/react-query": "^5.85.6",
     "@tanstack/react-query-devtools": "^5.85.6",
     "axios": "^1.10.0",
     "lucide-react": "^0.534.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.7.0",
     "recharts": "^3.1.2",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       '@tanstack/react-query':
         specifier: ^5.85.6
         version: 5.85.6(react@19.1.0)
@@ -26,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@19.1.0)
       react-router-dom:
         specifier: ^7.7.0
         version: 7.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -35,6 +41,9 @@ importers:
       three:
         specifier: ^0.179.1
         version: 0.179.1
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -371,6 +380,11 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1443,6 +1457,12 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@19.1.1:
     resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
 
@@ -1664,6 +1684,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -1981,6 +2009,11 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -3000,6 +3033,10 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-hook-form@7.62.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   react-is@19.1.1: {}
 
   react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1):
@@ -3250,6 +3287,10 @@ snapshots:
       react: 19.1.0
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   victory-vendor@37.3.6:
     dependencies:

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,62 +1,68 @@
-import React from 'react';
-import { Eye, EyeOff } from 'lucide-react';
+import React, { forwardRef, useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  label: string;
-  icon?: React.ReactNode;
-  error?: string | null;
+  label: string
+  icon?: React.ReactNode
+  error?: string | null
 }
 
-const Input = ({ label, id, type, icon, error, ...props }: InputProps) => {
-  const [isPasswordVisible, setPasswordVisible] = React.useState(false);
-  const isPasswordInput = type === 'password';
-  const inputType = isPasswordInput
-    ? isPasswordVisible
-      ? 'text'
-      : 'password'
-    : type;
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, id, type, icon, error, ...props }, ref) => {
+    const [isPasswordVisible, setPasswordVisible] = useState(false)
+    
+    const isPasswordInput = type === 'password'
+    const inputType = isPasswordInput
+      ? isPasswordVisible
+        ? 'text'
+        : 'password'
+      : type
 
-  const inputClasses = `
-    w-full py-3 border rounded-lg transition-all
-    bg-slate-100/70 border-transparent 
-    focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 focus:bg-white
-    ${icon ? 'pl-10' : 'pl-4'}
-    ${isPasswordInput ? 'pr-10' : 'pr-4'}
-    ${error ? 'border-red-500 ring-red-200' : ''}
-  `;
+    const inputClasses = `
+      w-full py-3 border rounded-lg transition-all
+      bg-slate-100/70 border-transparent 
+      focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 focus:bg-white
+      ${icon ? 'pl-10' : 'pl-4'}
+      ${isPasswordInput ? 'pr-10' : 'pr-4'}
+      ${error ? 'border-red-500 ring-red-200' : ''}
+    `
 
   return (
-    <div className="flex flex-col gap-2">
-      <label htmlFor={id} className="text-sm font-medium text-slate-700">
-        {label}
-      </label>
-      <div className="relative">
-        {icon && (
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none">
-            {icon}
-          </span>
-        )}
-        <input id={id} type={inputType} className={inputClasses} {...props} />
-        {isPasswordInput && (
-          <button
-            type="button"
-            onClick={() => setPasswordVisible(!isPasswordVisible)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
-            aria-label={
-              isPasswordVisible ? 'Ocultar contraseña' : 'Mostrar contraseña'
-            }
-          >
-            {isPasswordVisible ? (
-              <EyeOff className="h-5 w-5" />
-            ) : (
-              <Eye className="h-5 w-5" />
-            )}
-          </button>
-        )}
+      <div className="flex flex-col gap-2">
+        <label htmlFor={id} className="text-sm font-medium text-slate-700">
+          {label}
+        </label>
+        <div className="relative">
+          {icon && (
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none">
+              {icon}
+            </span>
+          )}
+          <input id={id} type={inputType} className={inputClasses} ref={ref} {...props} />
+          
+          {isPasswordInput && (
+            <button
+              type="button"
+              onClick={() => setPasswordVisible(!isPasswordVisible)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+              aria-label={
+                isPasswordVisible ? 'Ocultar contraseña' : 'Mostrar contraseña'
+              }
+            >
+              {isPasswordVisible ? (
+                <EyeOff className="h-5 w-5" />
+              ) : (
+                <Eye className="h-5 w-5" />
+              )}
+            </button>
+          )}
+        </div>
+        {error && <p className="text-sm text-red-500 mt-1">{error}</p>}
       </div>
-      {error && <p className="text-sm text-red-500 mt-1">{error}</p>}
-    </div>
-  );
-};
+    )
+  }
+)
 
-export default Input;
+Input.displayName = 'Input'
+
+export default Input

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
+import React from 'react'
 
 interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
-  label: string;
-  icon?: React.ReactNode; 
+  label: string
+  icon?: React.ReactNode
+  error?: string | null 
 }
 
-const Textarea = ({ id, label, icon, ...props }: TextareaProps) => {
+const Textarea = ({ id, label, icon, error, ...props }: TextareaProps) => {
   const textareaClasses = `
     w-full flex min-h-[120px] p-4 border rounded-lg transition-all
     bg-slate-100/70 border-transparent 
     focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 focus:bg-white
     resize-none text-sm placeholder:text-slate-500
-    ${icon ? 'pl-10' : ''} 
-  `;
+    ${icon ? 'pl-10' : ''}
+    ${error ? 'border-red-500 ring-red-200' : ''}
+  `
 
   return (
     <div className="flex flex-col gap-2 w-full">
@@ -27,8 +29,9 @@ const Textarea = ({ id, label, icon, ...props }: TextareaProps) => {
         )}
         <textarea id={id} className={textareaClasses} {...props} />
       </div>
+      {error && <p className="text-sm text-red-500 mt-1">{error}</p>}
     </div>
-  );
-};
+  )
+}
 
-export default Textarea;
+export default Textarea

--- a/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/src/pages/Auth/ForgotPasswordPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import * as v from 'valibot'
+import { useForm } from 'react-hook-form'
+import { valibotResolver } from '@hookform/resolvers/valibot'
 import { Link } from 'react-router-dom'
-import type React from 'react'
 import { Mail, CheckCircle } from 'lucide-react'
 import { useForgotPassword } from '../../hooks/useAuthMutations.ts'
 import Button from '../../components/ui/Button'
@@ -8,13 +9,21 @@ import Input from '../../components/ui/Input'
 import AuthCard from '../../components/layouts/AuthCard'
 import { isAxiosError } from 'axios'
 
+const ForgotPasswordSchema = v.object({
+  mail: v.pipe(v.string(), v.email('Debe ser un email válido.')),
+})
+
+type ForgotPasswordFormData = v.InferInput<typeof ForgotPasswordSchema>
+
 const ForgotPasswordPage = () => {
-  const [email, setEmail] = useState('')
+  const { register, handleSubmit, formState: { errors }, getValues } = useForm<ForgotPasswordFormData>({
+    resolver: valibotResolver(ForgotPasswordSchema),
+  })
+  
   const { mutate: sendLink, isPending, isSuccess, error } = useForgotPassword()
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    sendLink(email)
+  const onSubmit = (data: ForgotPasswordFormData) => {
+    sendLink(data.mail)
   }
 
   return (
@@ -26,25 +35,23 @@ const ForgotPasswordPage = () => {
         <div className="text-center space-y-4">
             <CheckCircle className="w-16 h-16 text-green-500 mx-auto" />
             <p className="text-slate-600">
-                Si una cuenta con el correo <span className="font-semibold">{email}</span> existe, hemos enviado un enlace para restablecer tu contraseña.
+                Si una cuenta con el correo <span className="font-semibold">{getValues('mail')}</span> existe, hemos enviado un enlace.
             </p>
             <Link to="/login" className="font-medium text-blue-600 hover:underline">
                 Volver a Iniciar Sesión
             </Link>
         </div>
       ) : (
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
             <Input
             id="mail"
             label="Correo electrónico"
-            name="mail"
             type="email"
             placeholder="tu@email.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
             icon={<Mail className="h-5 w-5" />}
-            required
             autoComplete="email"
+            {...register('mail')}
+              error={errors.mail?.message}
             />
 
             {error && (

--- a/src/pages/Auth/RegisterPage.tsx
+++ b/src/pages/Auth/RegisterPage.tsx
@@ -1,143 +1,129 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import type React from 'react';
-import axios from 'axios';
-import { User, Mail, Lock } from 'lucide-react';
-import { authService } from '../../api/services/auth.service';
-import Button from '../../components/ui/Button';
-import Input from '../../components/ui/Input';
-import AuthCard from '../../components/layouts/AuthCard';
+import { Link } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { valibotResolver } from '@hookform/resolvers/valibot'
+import * as v from 'valibot'
+import { User, Mail, Lock } from 'lucide-react'
+import { useRegister } from '../../hooks/useAuthMutations'
+import Button from '../../components/ui/Button'
+import Input from '../../components/ui/Input'
+import AuthCard from '../../components/layouts/AuthCard'
+import { isAxiosError } from 'axios'
 
-const initialFormState = {
-  name: '',
-  surname: '',
-  mail: '',
-  password: '',
-  confirmPassword: '',
-};
+const RegisterObjectSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1, 'El nombre es requerido.')),
+  surname: v.pipe(v.string(), v.minLength(1, 'El apellido es requerido.')),
+  mail: v.pipe(v.string(), v.email('Debe ser un email válido.')),
+  password: v.pipe(v.string(), v.minLength(8, 'La contraseña debe tener al menos 8 caracteres.')),
+  confirmPassword: v.pipe(v.string(), v.minLength(1, 'Debes confirmar la contraseña.')),
+})
+
+const RegisterSchema = v.pipe(
+  RegisterObjectSchema,
+  v.forward(
+    v.partialCheck(
+      [['password'], ['confirmPassword']],
+      (input) => input.password === input.confirmPassword,
+      'Las contraseñas no coinciden.'
+    ),
+    ['confirmPassword']
+  )
+)
+
+type RegisterFormData = v.InferInput<typeof RegisterSchema>
 
 const RegisterPage = () => {
-  const [formData, setFormData] = useState(initialFormState);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const navigate = useNavigate();
+  const { register: formRegister, handleSubmit, formState: { errors } } = useForm<RegisterFormData>({
+    resolver: valibotResolver(RegisterSchema),
+    mode: 'onBlur',
+  })
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
-  };
+  const { mutate: registerUser, isPending, error } = useRegister()
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setError(null);
-
-    if (formData.password !== formData.confirmPassword) {
-      return setError('Las contraseñas no coinciden.');
+  const onSubmit = (data: RegisterFormData) => {
+    const payload = {
+      name: data.name,
+      surname: data.surname,
+      mail: data.mail,
+      password_plaintext: data.password,
     }
-    if (formData.password.length < 8) {
-      return setError('La contraseña debe tener al menos 8 caracteres.');
-    }
-
-    setIsLoading(true);
-    try {
-      const payload = {
-        name: formData.name,
-        surname: formData.surname,
-        mail: formData.mail,
-        password_plaintext: formData.password,
-      };
-      await authService.register(payload);
-      navigate('/login');
-    } catch (err) {
-      const message =
-        axios.isAxiosError(err) && err.response?.data?.message
-          ? err.response.data.message
-          : 'Ocurrió un error inesperado al intentar registrar la cuenta.';
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    registerUser(payload)
+  }
 
   return (
     <AuthCard
       title="Crea tu Cuenta"
       description="Completa el formulario para unirte a nosotros"
     >
-      <form onSubmit={handleSubmit} className="space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6">
           <Input
             id="name"
             label="Nombre"
-            name="name"
             type="text"
             placeholder="Darth"
-            value={formData.name}
-            onChange={handleChange}
             icon={<User className="h-5 w-5" />}
-            required
             autoComplete="given-name"
+            {...formRegister('name')} 
+            error={errors.name?.message}
           />
           <Input
             id="surname"
             label="Apellido"
-            name="surname"
             type="text"
             placeholder="Vader"
-            value={formData.surname}
-            onChange={handleChange}
             icon={<User className="h-5 w-5" />}
-            required
             autoComplete="family-name"
+            {...formRegister('surname')} 
+            error={errors.surname?.message}
           />
         </div>
 
         <Input
           id="mail"
           label="Correo Electrónico"
-          name="mail"
           type="email"
           placeholder="tu@email.com"
-          value={formData.mail}
-          onChange={handleChange}
           icon={<Mail className="h-5 w-5" />}
-          required
           autoComplete="email"
+          {...formRegister('mail')} 
+            error={errors.mail?.message}
         />
 
         <Input
           id="password"
           label="Contraseña"
-          name="password"
           type="password"
           placeholder="••••••••••"
-          value={formData.password}
-          onChange={handleChange}
           icon={<Lock className="h-5 w-5" />}
-          required
           autoComplete="new-password"
+          {...formRegister('password')} 
+            error={errors.password?.message}
         />
 
         <Input
           id="confirmPassword"
           label="Confirmar Contraseña"
-          name="confirmPassword"
           type="password"
           placeholder="••••••••••"
-          value={formData.confirmPassword}
-          onChange={handleChange}
           icon={<Lock className="h-5 w-5" />}
-          required
           autoComplete="new-password"
+          {...formRegister('confirmPassword')} 
+            error={errors.confirmPassword?.message}
         />
 
         {error && (
-          <p className="text-sm text-red-500 text-center -mt-2">{error}</p>
+          <p className="text-sm text-red-500 text-center">
+            {isAxiosError(error)
+              ? error.response?.data?.errors || 'Credenciales incorrectas.'
+              : 'Ocurrió un error inesperado.'
+            }
+          </p>
         )}
 
         <div className="pt-2">
           <Button
             type="submit"
-            isLoading={isLoading}
+            isLoading={isPending}
             className="w-full text-base py-3"
           >
             Registrarse
@@ -155,7 +141,7 @@ const RegisterPage = () => {
         </div>
       </form>
     </AuthCard>
-  );
-};
+  )
+}
 
-export default RegisterPage;
+export default RegisterPage


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
Closes #72

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
-->
Este PR refactoriza por completo la gestión de todos los formularios de la aplicación, migrando la lógica de `useState` a **React Hook Form** para el manejo del estado y a **Valibot** para la validación basada en esquemas. Esto mejora significativamente el rendimiento, la mantenibilidad y la seguridad de los formularios.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
-->
- **Instalación de Dependencias:**
    -   Se han añadido las librerías `react-hook-form`, `@hookform/resolvers` y `valibot` al proyecto.

- **Compatibilidad de Componentes de UI:**
    -   Se han refactorizado los componentes `Input.tsx` y `Textarea.tsx` para que utilicen `React.forwardRef`. Esto permite que React Hook Form se conecte directamente a los elementos del DOM, optimizando el rendimiento al evitar re-renders innecesarios.

- **Refactorización de Todos los Formularios:**
    -   **`RegisterPage.tsx`:** Se ha implementado un esquema de `Valibot` (`RegisterSchema`) que incluye validaciones complejas a nivel de objeto, como la confirmación de contraseñas.
    -   **`LoginPage.tsx`:** Se ha refactorizado para usar `useForm` con un `LoginSchema`, simplificando el componente.
    -   **`ProfessorAppeal.tsx`:** Se ha adaptado para usar `useForm` para los campos de texto, manteniendo un `useState` separado únicamente para la gestión del campo de archivo.
    -   **`CourseTypesPage.tsx`:** El formulario dentro del modal de creación/edición ahora es gestionado por React Hook Form.
    -   **`ForgotPasswordPage.tsx` y `ResetPasswordPage.tsx`:** Los formularios restantes del flujo de autenticación han sido completamente migrados, incluyendo validación de confirmación de contraseña en el reseteo.

- **Validación Robusta con Valibot:**
    -   Se ha estandarizado la sintaxis de los esquemas de `Valibot` en todos los formularios, utilizando `v.pipe`, `v.forward` y `v.custom` de la manera correcta para validaciones cruzadas.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
-->
1.  Iniciar el servidor del frontend (`pnpm dev`).
2.  **Probar el Formulario de Registro (`/register`):**
    -   Intentar enviar el formulario con campos vacíos y verificar que aparecen los mensajes de error de `Valibot`.
    -   Introducir contraseñas que no coinciden y verificar que aparece el mensaje "Las contraseñas no coinciden" en el campo de confirmación.
    -   Rellenar el formulario correctamente y verificar que la petición se envía.
3.  **Probar el Formulario de Login (`/login`):**
    -   Intentar enviar con campos vacíos y verificar los errores de validación.
4.  **Probar el Formulario de Solicitud de Profesor (`/professor/apply`):**
    -   Iniciar sesión como **estudiante**.
    -   Intentar enviar el formulario con el campo "Experiencia y motivación" con menos de 20 caracteres y verificar el error.
5.  **Probar el Formulario de Tipos de Curso (`/admin/courseTypes`):**
    -   Iniciar sesión como **administrador**.
    -   Abrir el modal para "Crear Nuevo Tipo", intentar guardar con campos vacíos y verificar los errores.
6.  **Probar el Flujo de Recuperación de Contraseña:**
    -   Ir a `/forgot-password` e intentar enviar un email inválido.
    -   Ir a `/reset-password` (con un token simulado en la URL) e intentar poner contraseñas que no coinciden.