### PR TITLE
feat: Checkbox "Recordarme" en Login

### DIFF
--- a/src/api/services/auth.service.ts
+++ b/src/api/services/auth.service.ts
@@ -9,7 +9,11 @@ interface ApiResponse<T> {
 }
 
 // Types for login and register requests
-type LoginPayload = { mail: string; password_plaintext: string };
+type LoginPayload = { 
+  mail: string; 
+  password_plaintext: string; 
+  rememberMe: boolean; 
+};
 type RegisterPayload = Omit<
   User,
   | 'password'

--- a/src/pages/Auth/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage.tsx
@@ -12,6 +12,7 @@ import { isAxiosError } from 'axios';
 const LoginSchema = v.object({
   mail: v.pipe(v.string(), v.email('Debe ser un email válido.')),
   password: v.pipe(v.string(), v.minLength(1, 'La contraseña es requerida.')),
+  rememberMe: v.boolean(),
 });
 
 type LoginFormData = v.InferInput<typeof LoginSchema>;
@@ -31,6 +32,7 @@ const LoginPage = () => {
     const payload = {
       mail: data.mail,
       password_plaintext: data.password,
+      rememberMe: data.rememberMe,
     };
     login(payload);
   };
@@ -65,9 +67,9 @@ const LoginPage = () => {
           <div className="flex items-center gap-2">
             <input
               id="remember"
-              name="remember"
               type="checkbox"
               className="h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-500"
+              {...formRegister('rememberMe')}
             />
             <label htmlFor="remember" className="text-slate-600 cursor-pointer">
               Recordarme


### PR DESCRIPTION
### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
Este PR implementa la interfaz de usuario necesaria para que el usuario pueda elegir si desea mantener su sesión iniciada, enviando esta preferencia al servidor durante el proceso de autenticación.

### Cambios Técnicos Implementados
- **UI:** Se añadió un checkbox "Recordarme" (*Remember me*) en el formulario `LoginPage.tsx` utilizando `react-hook-form`.
- **API:** Se actualizó la función y el tipo `LoginPayload` en `auth.service.ts` para enviar la propiedad `rememberMe: boolean` al backend.
- **Validación:** Se actualizó el esquema de validación (Valibot) para soportar el nuevo campo.

---

### Guía para Pruebas y Revisión
1.  Iniciar la aplicación.
2.  Ir a `/login`.
3.  **Verificar UI:** El checkbox debe aparecer alineado junto al enlace de recuperación de contraseña.
4.  **Verificar Envío:**
    - Abrir Network Tab en el navegador.
    - Hacer login marcando la casilla.
    - Verificar que el payload del POST a `/login` incluye `rememberMe: true`.
