### PR TITLE
feat: Restricción de medios en editor y correcciones de UI

### DIFF
--- a/src/components/landing/UnitEditor.tsx
+++ b/src/components/landing/UnitEditor.tsx
@@ -1,9 +1,13 @@
-import { useCreateBlockNote } from '@blocknote/react';
+import { 
+  useCreateBlockNote, 
+  getDefaultReactSlashMenuItems, 
+  SuggestionMenuController 
+} from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/mantine';
+import { filterSuggestionItems } from '@blocknote/core';
 import '@blocknote/mantine/style.css';
 import '@blocknote/core/fonts/inter.css';
 import type { Block, PartialBlock } from '@blocknote/core';
-import { useUploadUnitFile } from '../../hooks/useUnits.ts';
 import { useEffect } from 'react';
 
 interface UnitEditorProps {
@@ -17,16 +21,8 @@ export default function UnitEditor({
   initialContent,
   onChange,
 }: UnitEditorProps) {
-  const { mutateAsync: uploadFileToServer } = useUploadUnitFile();
-
-  const uploadFile = async (file: File): Promise<string> => {
-    const url = await uploadFileToServer(file);
-    return url;
-  };
-
-  const editor = useCreateBlockNote({
-    uploadFile,
-  });
+  
+  const editor = useCreateBlockNote({});
 
   useEffect(() => {
     if (editor) {
@@ -52,8 +48,18 @@ export default function UnitEditor({
     }
   }, [editor, initialContent]);
 
+  const forbiddenItems = ['Image', 'Video', 'Audio', 'File'];
+
+  const getCustomSlashMenuItems = (query: string) => {
+    const defaultItems = getDefaultReactSlashMenuItems(editor);
+    const filteredItems = defaultItems.filter(
+      (item) => !forbiddenItems.includes(item.title)
+    );
+    return filterSuggestionItems(filteredItems, query);
+  };
+
   return (
-    <div className="blocknote-editor-wrapper relative">
+    <div className="blocknote-editor-wrapper relative z-10">
       <BlockNoteView
         theme="light"
         editable={editable}
@@ -61,7 +67,13 @@ export default function UnitEditor({
         onChange={() => {
           onChange(editor.document);
         }}
-      />
+        slashMenu={false} 
+      >
+        <SuggestionMenuController
+          triggerCharacter={'/'}
+          getItems={async (query) => getCustomSlashMenuItems(query)}
+        />
+      </BlockNoteView>
     </div>
   );
 }

--- a/src/components/professor/courseEditor/CourseHeader.tsx
+++ b/src/components/professor/courseEditor/CourseHeader.tsx
@@ -33,75 +33,80 @@ export default function CourseHeader({
 
   return (
     <div className="mb-8">
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex flex-wrap items-center gap-2 mb-4">
         <Link to="/professor/dashboard/courses">
           <Button
             variant="ghost"
             className="text-slate-600 hover:text-slate-800"
+            size="sm"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />
-            Volver a Mis Cursos
+            Volver
           </Button>
         </Link>
         {courseId && (
           <>
             <Button
               variant="outline"
+              size="sm"
               onClick={() => navigate(`/professor/dashboard/assessments?courseId=${courseId}`)}
               className="flex items-center gap-2"
             >
               <FileText className="w-4 h-4" />
-              Ver Evaluaciones del Curso
+              Evaluaciones
             </Button>
             {onOpenGeneralQuestions && (
               <Button
                 variant="outline"
+                size="sm"
                 onClick={onOpenGeneralQuestions}
                 className="flex items-center gap-2"
               >
                 <HelpCircle className="w-4 h-4" />
-                Preguntas Generales
+                Preguntas Gral.
               </Button>
             )}
           </>
         )}
       </div>
 
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
-          <h1 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-2">
+          <h1 className="text-2xl lg:text-4xl font-bold text-slate-800 mb-1">
             {courseName}
           </h1>
-          <p className="text-lg text-slate-600">
-            Edita el contenido, las actividades y la configuración de tu curso.
+          <p className="text-sm lg:text-lg text-slate-600">
+            Edita el contenido y configuración.
           </p>
         </div>
 
-        <div className="flex items-center space-x-3">
+        <div className="flex flex-wrap items-center gap-3">
           <SaveStatus
             hasUnsavedChanges={hasUnsavedChanges}
             isLoading={isSaving}
             error={saveError}
             lastSavedAt={lastSavedAt}
           />
+          
           <Button
             onClick={onSave}
             isLoading={isSaving}
             disabled={isSaving}
-            className="bg-green-500 hover:bg-green-600"
+            className="bg-green-500 hover:bg-green-600 whitespace-nowrap"
+            size="md"
           >
-            Guardar Cambios
+            Guardar
           </Button>
 
-          <div className="flex items-center gap-3 bg-slate-50 rounded-lg px-4 py-2 border border-slate-200">
-            <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 bg-slate-50 rounded-lg px-3 py-2 border border-slate-200">
+            <div className="flex items-center gap-1.5">
               <Eye
                 className={`w-4 h-4 ${
                   !isEditMode ? 'text-blue-600' : 'text-slate-400'
                 }`}
               />
               <span
-                className={`text-sm font-medium ${
+                className={`text-xs font-medium uppercase ${
                   !isEditMode ? 'text-slate-700' : 'text-slate-400'
                 }`}
               >
@@ -113,18 +118,18 @@ export default function CourseHeader({
               checked={isEditMode}
               onChange={onToggleEdit}
             />
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               <Edit
                 className={`w-4 h-4 ${
                   isEditMode ? 'text-blue-600' : 'text-slate-400'
                 }`}
               />
               <span
-                className={`text-sm font-medium ${
+                className={`text-xs font-medium uppercase ${
                   isEditMode ? 'text-slate-700' : 'text-slate-400'
                 }`}
               >
-                Editar
+                Edit
               </span>
             </div>
           </div>

--- a/src/components/professor/courseEditor/UnitContent.tsx
+++ b/src/components/professor/courseEditor/UnitContent.tsx
@@ -18,13 +18,13 @@ import {
 } from 'lucide-react';
 import DocumentViewer from '../../ui/DocumentViewer/DocumentViewer';
 import UnitEditor from '../../landing/UnitEditor';
-// import ActivityCard from '../../landing/professorCourseEdition/ActivityCard'; // Obsoleto, ahora usamos questions
 import type { Block } from '@blocknote/core';
 import type {
   UnitEditorData,
   Question,
   Material,
 } from '../../../types/entities';
+import { cn } from '../../../lib/utils';
 
 interface UnitContentProps {
   selectedUnit: UnitEditorData | null;
@@ -75,7 +75,12 @@ export default function UnitContent({
 
   return (
     <div className="space-y-6">
-      <Card className={editable ? 'ring-2 ring-blue-200 ring-offset-2' : ''}>
+      <Card 
+        className={cn(
+          "relative z-20", 
+          editable && 'ring-2 ring-blue-200 ring-offset-2'
+        )}
+      >
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
@@ -115,7 +120,7 @@ export default function UnitContent({
         </CardContent>
       </Card>
 
-      <div className="grid md:grid-cols-2 gap-6">
+      <div className="grid md:grid-cols-2 gap-6 relative z-0">
         <Card>
           <CardHeader>
             <CardTitle className="text-lg">Preguntas de la Unidad</CardTitle>
@@ -238,7 +243,6 @@ export default function UnitContent({
         </Card>
       </div>
 
-      {/* Modal de previsualización de materiales */}
       {previewMaterial && (
         <DocumentViewer
           url={previewMaterial.url}

--- a/src/index.css
+++ b/src/index.css
@@ -82,4 +82,10 @@
   }
 }
 
-/* BlockNote Editor Z-Index - Configuración nativa */
+.bn-suggestion-menu {
+  z-index: 99999 !important;
+}
+
+.blocknote-editor-wrapper {
+  overflow: visible !important;
+}


### PR DESCRIPTION
### Issue Relacionada
No aplica

---

### Resumen
Este PR implementa la tarea de limitar el editor de texto para que sea solo texto y soluciona dos bugs visuales críticos reportados en la vista de edición del profesor: el header roto en móviles y el menú de comandos que quedaba oculto bajo las tarjetas.

### Cambios Técnicos Implementados
- **Editor (BlockNote):**
    - Se eliminó la función `uploadFile` en `UnitEditor.tsx` para deshabilitar la subida nativa.
    - Se implementó `SuggestionMenuController` para filtrar opciones multimedia (Image, Video, Audio, File) del menú `/`.
- **UI Header:** 
    - Se aplicó `flex-wrap` en `CourseHeader.tsx` para que los botones de acción se acomoden correctamente en pantallas pequeñas (móviles).
- **UI Z-Index:** 
    - Se añadió `z-10` al contenedor del editor en `UnitEditor.tsx`.
    - Se añadió `relative z-20` al componente `Card` contenedor en `UnitContent.tsx` para forzar un contexto de apilamiento superior sobre las tarjetas de preguntas/materiales.

---

### Guía para Pruebas y Revisión
1.  **Prueba de Restricción:**
    - Entrar a editar una unidad.
    - Escribir `/` y verificar que NO aparecen opciones de imagen/video.
    - Arrastrar una imagen al editor y verificar que no se sube.
2.  **Prueba Responsiva:**
    - Abrir la vista de edición de curso.
    - Reducir el ancho de la ventana a tamaño móvil (< 400px).
    - Verificar que el título y los botones del header no se superponen ni se cortan.
3.  **Prueba de Menú (Z-Index):**
    - En una unidad que tenga preguntas debajo, escribir `/` en la última línea del editor.
    - Verificar que el menú desplegable flota **por encima** de la tarjeta de "Preguntas de la Unidad".
